### PR TITLE
Net device support

### DIFF
--- a/src/fc/fc_monitor.h
+++ b/src/fc/fc_monitor.h
@@ -43,5 +43,12 @@ virFCMonitorShutdownVM(const char *socketpath);
 int virFCMonitorChangeState(const char *socketpath,
                             const char *state);
 
+int
+virFCMonitorSetNetwork(const char *socketpath,
+                              const char *iface_id,
+                              const char *guest_mac,
+                              const char *host_dev_name,
+                              const bool allow_mmds_requests);
+
 virDomainState
 virFCMonitorGetStatus(const char *socketpath);


### PR DESCRIPTION
Using an `<interface>` tag under `<devices>` we can configure a tap device to be set up before booting the vm

Example: 
```XML
<interface type='ethernet'>
      <target dev='tap0'/>
      <guest dev='eth0'/>
</interface>
```

We use an interface of type 'ethernet' on the host with the interface name on the guest `eth0` that ties to the tap device on the host named `tap0`

Details on how to configure the tap device on both host and the guest can be found on the firecracker [networking guide](https://github.com/firecracker-microvm/firecracker/blob/main/docs/network-setup.md)